### PR TITLE
Sync OSGi handling with Apache JClouds Project

### DIFF
--- a/openstack-glance/bnd.bnd
+++ b/openstack-glance/bnd.bnd
@@ -1,0 +1,2 @@
+Export-Package: \
+    org.jclouds.openstack.glance.*;version="${project.version}";-noimport:=true

--- a/openstack-glance/pom.xml
+++ b/openstack-glance/pom.xml
@@ -32,7 +32,6 @@
   <version>2.3.0-SNAPSHOT</version>
   <name>jclouds openstack-glance api</name>
   <description>jclouds components to access an implementation of OpenStack Glance</description>
-  <packaging>bundle</packaging>
 
   <properties>
     <!-- keystone endpoint -->
@@ -43,9 +42,6 @@
     <test.openstack-glance.identity>FIXME_IDENTITY</test.openstack-glance.identity>
     <test.openstack-glance.credential>FIXME_CREDENTIALS</test.openstack-glance.credential>
     <test.jclouds.keystone.credential-type>passwordCredentials</test.jclouds.keystone.credential-type>
-
-    <jclouds.osgi.export>org.jclouds.openstack.glance.*;version="${project.version}"</jclouds.osgi.export>
-    <jclouds.osgi.import>org.jclouds*;version="${project.version}",*</jclouds.osgi.import>
   </properties>
 
   <repositories>

--- a/openstack-heat/bnd.bnd
+++ b/openstack-heat/bnd.bnd
@@ -1,0 +1,2 @@
+Export-Package: \
+    org.jclouds.openstack.heat.v1.*;version="${project.version}";-noimport:=true

--- a/openstack-heat/pom.xml
+++ b/openstack-heat/pom.xml
@@ -32,7 +32,6 @@
   <version>2.3.0-SNAPSHOT</version>
   <name>Apache jclouds :: OpenStack :: Heat API</name>
   <description>jclouds components to access an implementation of OpenStack Heat</description>
-  <packaging>bundle</packaging>
 
   <properties>
     <!-- keystone endpoint -->
@@ -42,8 +41,6 @@
     <test.openstack-heat.identity>FIXME_IDENTITY</test.openstack-heat.identity>
     <test.openstack-heat.credential>FIXME_CREDENTIALS</test.openstack-heat.credential>
     <test.jclouds.keystone.credential-type>passwordCredentials</test.jclouds.keystone.credential-type>
-    <jclouds.osgi.export>org.jclouds.openstack.heat.v1*;version="${project.version}"</jclouds.osgi.export>
-    <jclouds.osgi.import>org.jclouds*;version="${project.version}",*</jclouds.osgi.import>
   </properties>
 
   <repositories>

--- a/openstack-marconi/bnd.bnd
+++ b/openstack-marconi/bnd.bnd
@@ -1,0 +1,2 @@
+Export-Package: \
+    org.jclouds.openstack.marconi.v1.*;version="${project.version}";-noimport:=true

--- a/openstack-marconi/pom.xml
+++ b/openstack-marconi/pom.xml
@@ -32,7 +32,6 @@
   <version>2.3.0-SNAPSHOT</version>
   <name>jclouds openstack-marconi api</name>
   <description>jclouds components to access an implementation of OpenStack Marconi</description>
-  <packaging>bundle</packaging>
 
   <properties>
     <!-- keystone endpoint -->
@@ -42,8 +41,6 @@
     <test.openstack-marconi.identity>FIXME_IDENTITY</test.openstack-marconi.identity>
     <test.openstack-marconi.credential>FIXME_CREDENTIALS</test.openstack-marconi.credential>
     <test.jclouds.keystone.credential-type>passwordCredentials</test.jclouds.keystone.credential-type>
-    <jclouds.osgi.export>org.jclouds.openstack.marconi.v1*;version="${project.version}"</jclouds.osgi.export>
-    <jclouds.osgi.import>org.jclouds*;version="${project.version}",*</jclouds.osgi.import>
   </properties>
 
   <repositories>

--- a/openstack-poppy/bnd.bnd
+++ b/openstack-poppy/bnd.bnd
@@ -1,0 +1,2 @@
+Export-Package: \
+    org.jclouds.openstack.poppy.v1.*;version="${project.version}";-noimport:=true

--- a/openstack-poppy/pom.xml
+++ b/openstack-poppy/pom.xml
@@ -32,7 +32,6 @@
   <version>2.3.0-SNAPSHOT</version>
   <name>Apache jclouds :: OpenStack :: Poppy API</name>
   <description>jclouds components to access an implementation of OpenStack Poppy</description>
-  <packaging>bundle</packaging>
 
   <properties>
     <!-- keystone endpoint -->
@@ -42,8 +41,6 @@
     <test.openstack-poppy.identity>FIXME_IDENTITY</test.openstack-poppy.identity>
     <test.openstack-poppy.credential>FIXME_CREDENTIALS</test.openstack-poppy.credential>
     <test.jclouds.keystone.credential-type>passwordCredentials</test.jclouds.keystone.credential-type>
-    <jclouds.osgi.export>org.jclouds.openstack.poppy.v1*;version="${project.version}"</jclouds.osgi.export>
-    <jclouds.osgi.import>org.jclouds*;version="${project.version}",*</jclouds.osgi.import>
   </properties>
 
   <dependencies>

--- a/rackspace-autoscale-uk/bnd.bnd
+++ b/rackspace-autoscale-uk/bnd.bnd
@@ -1,0 +1,2 @@
+Export-Package: \
+    org.jclouds.rackspace.autoscale.uk.*;version="${project.version}";-noimport:=true

--- a/rackspace-autoscale-uk/pom.xml
+++ b/rackspace-autoscale-uk/pom.xml
@@ -33,7 +33,6 @@
   <version>2.3.0-SNAPSHOT</version>
   <name>jclouds Rackspace Auto Scale UK Provider</name>
   <description>jclouds components to access Rackspace Auto Scale UK</description>
-  <packaging>bundle</packaging>
 
   <properties>
     <!-- keystone endpoint -->
@@ -44,8 +43,6 @@
     <test.rackspace-autoscale.identity>FIXME_IDENTITY</test.rackspace-autoscale.identity>
     <test.rackspace-autoscale.credential>FIXME_CREDENTIALS</test.rackspace-autoscale.credential>
     <test.jclouds.keystone.credential-type>passwordCredentials</test.jclouds.keystone.credential-type>
-    <jclouds.osgi.export>org.jclouds.rackspace.autoscale.uk*;version="${project.version}"</jclouds.osgi.export>
-    <jclouds.osgi.import>org.jclouds*;version="${project.version}",*</jclouds.osgi.import>
   </properties>
 
   <repositories>

--- a/rackspace-autoscale-us/bnd.bnd
+++ b/rackspace-autoscale-us/bnd.bnd
@@ -1,0 +1,2 @@
+Export-Package: \
+    org.jclouds.rackspace.autoscale.us.*;version="${project.version}";-noimport:=true

--- a/rackspace-autoscale-us/pom.xml
+++ b/rackspace-autoscale-us/pom.xml
@@ -32,7 +32,6 @@
   <version>2.3.0-SNAPSHOT</version>
   <name>jclouds Rackspace Auto Scale US Provider</name>
   <description>jclouds components to access Rackspace Autoscale</description>
-  <packaging>bundle</packaging>
 
   <properties>
     <!-- keystone endpoint -->
@@ -43,8 +42,6 @@
     <test.rackspace-autoscale.identity>FIXME_IDENTITY</test.rackspace-autoscale.identity>
     <test.rackspace-autoscale.credential>FIXME_CREDENTIALS</test.rackspace-autoscale.credential>
     <test.jclouds.keystone.credential-type>passwordCredentials</test.jclouds.keystone.credential-type>
-    <jclouds.osgi.export>org.jclouds.rackspace.autoscale.us*;version="${project.version}"</jclouds.osgi.export>
-    <jclouds.osgi.import>org.jclouds*;version="${project.version}",*</jclouds.osgi.import>
   </properties>
 
   <repositories>

--- a/rackspace-autoscale/bnd.bnd
+++ b/rackspace-autoscale/bnd.bnd
@@ -1,0 +1,2 @@
+Export-Package: \
+    org.jclouds.rackspace.autoscale.v1.*;version="${project.version}";-noimport:=true

--- a/rackspace-autoscale/pom.xml
+++ b/rackspace-autoscale/pom.xml
@@ -32,7 +32,6 @@
   <version>2.3.0-SNAPSHOT</version>
   <name>jclouds Rackspace Auto Scale API</name>
   <description>jclouds components to access Rackspace Autoscale</description>
-  <packaging>bundle</packaging>
 
   <properties>
     <!-- keystone endpoint -->
@@ -43,8 +42,6 @@
     <test.rackspace-autoscale.identity>FIXME_IDENTITY</test.rackspace-autoscale.identity>
     <test.rackspace-autoscale.credential>FIXME_CREDENTIALS</test.rackspace-autoscale.credential>
     <test.jclouds.keystone.credential-type>passwordCredentials</test.jclouds.keystone.credential-type>
-    <jclouds.osgi.export>org.jclouds.rackspace.autoscale.v1_0*;version="${project.version}"</jclouds.osgi.export>
-    <jclouds.osgi.import>org.jclouds*;version="${project.version}",*</jclouds.osgi.import>
   </properties>
 
   <repositories>

--- a/rackspace-cdn-uk/bnd.bnd
+++ b/rackspace-cdn-uk/bnd.bnd
@@ -1,0 +1,2 @@
+Export-Package: \
+    org.jclouds.rackspace.cdn.uk.*;version="${project.version}";-noimport:=true

--- a/rackspace-cdn-uk/pom.xml
+++ b/rackspace-cdn-uk/pom.xml
@@ -32,7 +32,6 @@
   <version>2.3.0-SNAPSHOT</version>
   <name>jclouds Rackspace CDN UK provider</name>
   <description>OpenStack Poppy implementation targeted to Rackspace CDN UK</description>
-  <packaging>bundle</packaging>
 
   <properties>
     <!-- identity endpoint -->
@@ -41,8 +40,6 @@
     <test.rackspace-cdn-uk.build-version />
     <test.rackspace-cdn-uk.identity>${test.rackspace-uk.identity}</test.rackspace-cdn-uk.identity>
     <test.rackspace-cdn-uk.credential>${test.rackspace-uk.credential}</test.rackspace-cdn-uk.credential>
-    <jclouds.osgi.export>org.jclouds.rackspace.cdn.uk*;version="${project.version}"</jclouds.osgi.export>
-    <jclouds.osgi.import>org.jclouds*;version="${project.version}",*</jclouds.osgi.import>
   </properties>
 
   <dependencies>

--- a/rackspace-cdn-us/bnd.bnd
+++ b/rackspace-cdn-us/bnd.bnd
@@ -1,0 +1,2 @@
+Export-Package: \
+    org.jclouds.rackspace.cdn.us.*;version="${project.version}";-noimport:=true

--- a/rackspace-cdn-us/pom.xml
+++ b/rackspace-cdn-us/pom.xml
@@ -32,7 +32,6 @@
   <version>2.3.0-SNAPSHOT</version>
   <name>jclouds Rackspace CDN US provider</name>
   <description>OpenStack Poppy implementation targeted to Rackspace CDN US</description>
-  <packaging>bundle</packaging>
 
   <properties>
     <!-- identity endpoint -->
@@ -41,8 +40,6 @@
     <test.rackspace-cdn-us.build-version />
     <test.rackspace-cdn-us.identity>${test.rackspace-us.identity}</test.rackspace-cdn-us.identity>
     <test.rackspace-cdn-us.credential>${test.rackspace-us.credential}</test.rackspace-cdn-us.credential>
-    <jclouds.osgi.export>org.jclouds.rackspace.cdn.us*;version="${project.version}"</jclouds.osgi.export>
-    <jclouds.osgi.import>org.jclouds*;version="${project.version}",*</jclouds.osgi.import>
   </properties>
 
   <dependencies>

--- a/rackspace-cloudbigdata-us/bnd.bnd
+++ b/rackspace-cloudbigdata-us/bnd.bnd
@@ -1,0 +1,2 @@
+Export-Package: \
+    org.jclouds.rackspace.cloudbigdata.us.v1.*;version="${project.version}";-noimport:=true

--- a/rackspace-cloudbigdata-us/pom.xml
+++ b/rackspace-cloudbigdata-us/pom.xml
@@ -32,7 +32,6 @@
   <version>2.3.0-SNAPSHOT</version>
   <name>jclouds rackspace-cloudbigdata api provider</name>
   <description>jclouds components to access Rackspace Autoscale</description>
-  <packaging>bundle</packaging>
 
   <properties>
     <!-- keystone endpoint -->
@@ -43,8 +42,6 @@
     <test.rackspace-cloudbigdata.identity>FIXME_IDENTITY</test.rackspace-cloudbigdata.identity>
     <test.rackspace-cloudbigdata.credential>FIXME_CREDENTIALS</test.rackspace-cloudbigdata.credential>
     <test.jclouds.keystone.credential-type>passwordCredentials</test.jclouds.keystone.credential-type>
-    <jclouds.osgi.export>org.jclouds.rackspace.cloudbigdata.v1_0*;version="${project.version}"</jclouds.osgi.export>
-    <jclouds.osgi.import>org.jclouds*;version="${project.version}",*</jclouds.osgi.import>
   </properties>
 
   <repositories>

--- a/rackspace-cloudbigdata/bnd.bnd
+++ b/rackspace-cloudbigdata/bnd.bnd
@@ -1,0 +1,2 @@
+Export-Package: \
+    org.jclouds.rackspace.cloudbigdata.v1.*;version="${project.version}";-noimport:=true

--- a/rackspace-cloudbigdata/pom.xml
+++ b/rackspace-cloudbigdata/pom.xml
@@ -32,7 +32,6 @@
   <version>2.3.0-SNAPSHOT</version>
   <name>jclouds rackspace-cloudbigdata api</name>
   <description>jclouds components to access Rackspace Cloud Big Data</description>
-  <packaging>bundle</packaging>
 
   <properties>
     <!-- keystone endpoint -->
@@ -43,8 +42,6 @@
     <test.rackspace-cloudbigdata.identity>FIXME_IDENTITY</test.rackspace-cloudbigdata.identity>
     <test.rackspace-cloudbigdata.credential>FIXME_CREDENTIALS</test.rackspace-cloudbigdata.credential>
     <test.jclouds.keystone.credential-type>passwordCredentials</test.jclouds.keystone.credential-type>
-    <jclouds.osgi.export>org.jclouds.rackspace.cloudbigdata.v1_0*;version="${project.version}"</jclouds.osgi.export>
-    <jclouds.osgi.import>org.jclouds*;version="${project.version}",*</jclouds.osgi.import>
   </properties>
 
   <repositories>

--- a/rackspace-cloudqueues-uk/bnd.bnd
+++ b/rackspace-cloudqueues-uk/bnd.bnd
@@ -1,0 +1,2 @@
+Export-Package: \
+    org.jclouds.rackspace.cloudqueues.uk.*;version="${project.version}";-noimport:=true

--- a/rackspace-cloudqueues-uk/pom.xml
+++ b/rackspace-cloudqueues-uk/pom.xml
@@ -33,7 +33,6 @@
   <version>2.3.0-SNAPSHOT</version>
   <name>jclouds Rackspace Cloud Queues UK provider</name>
   <description>OpenStack Marconi implementation targeted to Rackspace Cloud Queues UK</description>
-  <packaging>bundle</packaging>
 
   <properties>
     <test.rackspace-cloudqueues-uk.endpoint>https://lon.identity.api.rackspacecloud.com/v2.0/</test.rackspace-cloudqueues-uk.endpoint>
@@ -42,8 +41,6 @@
     <test.rackspace-cloudqueues-uk.identity>${test.rackspace-uk.identity}</test.rackspace-cloudqueues-uk.identity>
     <test.rackspace-cloudqueues-uk.credential>${test.rackspace-uk.credential}</test.rackspace-cloudqueues-uk.credential>
     <test.rackspace-cloudqueues-uk.template />
-    <jclouds.osgi.export>org.jclouds.rackspace.cloudqueues.uk*;version="${project.version}"</jclouds.osgi.export>
-    <jclouds.osgi.import>org.jclouds*;version="${project.version}",*</jclouds.osgi.import>
   </properties>
 
   <repositories>

--- a/rackspace-cloudqueues-us/bnd.bnd
+++ b/rackspace-cloudqueues-us/bnd.bnd
@@ -1,0 +1,2 @@
+Export-Package: \
+    org.jclouds.rackspace.cloudqueues.us.*;version="${project.version}";-noimport:=true

--- a/rackspace-cloudqueues-us/pom.xml
+++ b/rackspace-cloudqueues-us/pom.xml
@@ -33,7 +33,6 @@
   <version>2.3.0-SNAPSHOT</version>
   <name>jclouds Rackspace Cloud Queues US provider</name>
   <description>OpenStack Marconi implementation targeted to Rackspace Cloud Queues US</description>
-  <packaging>bundle</packaging>
 
   <properties>
     <test.rackspace-cloudqueues-us.endpoint>https://identity.api.rackspacecloud.com/v2.0/</test.rackspace-cloudqueues-us.endpoint>
@@ -42,8 +41,6 @@
     <test.rackspace-cloudqueues-us.identity>${test.rackspace-us.identity}</test.rackspace-cloudqueues-us.identity>
     <test.rackspace-cloudqueues-us.credential>${test.rackspace-us.credential}</test.rackspace-cloudqueues-us.credential>
     <test.rackspace-cloudqueues-us.template />
-    <jclouds.osgi.export>org.jclouds.rackspace.cloudqueues.us*;version="${project.version}"</jclouds.osgi.export>
-    <jclouds.osgi.import>org.jclouds*;version="${project.version}",*</jclouds.osgi.import>
   </properties>
 
   <repositories>

--- a/rackspace-orchestration-uk/bnd.bnd
+++ b/rackspace-orchestration-uk/bnd.bnd
@@ -1,0 +1,2 @@
+Export-Package: \
+    org.jclouds.rackspace.orchestration.uk.*;version="${project.version}";-noimport:=true

--- a/rackspace-orchestration-uk/pom.xml
+++ b/rackspace-orchestration-uk/pom.xml
@@ -32,7 +32,6 @@
   <version>2.3.0-SNAPSHOT</version>
   <name>jclouds Rackspace Orchestration UK provider</name>
   <description>OpenStack Heat implementation targeted to Rackspace Orchestration UK</description>
-  <packaging>bundle</packaging>
 
   <properties>
     <!-- identity endpoint -->
@@ -41,8 +40,6 @@
     <test.rackspace-orchestration-uk.build-version />
     <test.rackspace-orchestration-uk.identity>${test.rackspace-uk.identity}</test.rackspace-orchestration-uk.identity>
     <test.rackspace-orchestration-uk.credential>${test.rackspace-uk.credential}</test.rackspace-orchestration-uk.credential>
-    <jclouds.osgi.export>org.jclouds.rackspace.orchestration.uk*;version="${project.version}"</jclouds.osgi.export>
-    <jclouds.osgi.import>org.jclouds*;version="${project.version}",*</jclouds.osgi.import>
   </properties>
 
   <dependencies>

--- a/rackspace-orchestration-us/bnd.bnd
+++ b/rackspace-orchestration-us/bnd.bnd
@@ -1,0 +1,2 @@
+Export-Package: \
+    org.jclouds.rackspace.orchestration.us.*;version="${project.version}";-noimport:=true

--- a/rackspace-orchestration-us/pom.xml
+++ b/rackspace-orchestration-us/pom.xml
@@ -32,7 +32,6 @@
   <version>2.3.0-SNAPSHOT</version>
   <name>jclouds Rackspace Orchestration US provider</name>
   <description>OpenStack Heat implementation targeted to Rackspace Orchestration US</description>
-  <packaging>bundle</packaging>
 
   <properties>
     <!-- identity endpoint -->
@@ -41,8 +40,6 @@
     <test.rackspace-orchestration-us.build-version />
     <test.rackspace-orchestration-us.identity>${test.rackspace-us.identity}</test.rackspace-orchestration-us.identity>
     <test.rackspace-orchestration-us.credential>${test.rackspace-us.credential}</test.rackspace-orchestration-us.credential>
-    <jclouds.osgi.export>org.jclouds.rackspace.orchestration.us*;version="${project.version}"</jclouds.osgi.export>
-    <jclouds.osgi.import>org.jclouds*;version="${project.version}",*</jclouds.osgi.import>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This project, the openstack-lab version of Apache JClouds, share the exact build instructions as the primary Apache JClouds project with all its modules.
Apache JClouds is shifting its strategy in handling OSGi configuration. Instead of using the Maven Bundle Plugin, a wrapper of the BND plugin, the BND plugin gets used directly.
- Remove the OSGi configuration from each module. The configuration gets served to the BND through dedicated configuration / bnd files.
- Onboard bnd-configuration files, one per module.