### PR TITLE
Upgrade OKHttp dependency

### DIFF
--- a/openstack-heat/pom.xml
+++ b/openstack-heat/pom.xml
@@ -88,7 +88,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.squareup.okhttp</groupId>
+      <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
       <scope>test</scope>
     </dependency>

--- a/openstack-heat/src/test/java/org/jclouds/openstack/heat/v1/features/ResourceApiMockTest.java
+++ b/openstack-heat/src/test/java/org/jclouds/openstack/heat/v1/features/ResourceApiMockTest.java
@@ -24,8 +24,8 @@ import org.jclouds.openstack.heat.v1.HeatApi;
 import org.jclouds.openstack.heat.v1.internal.BaseHeatApiMockTest;
 import org.testng.annotations.Test;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 
 /**
  * Tests annotation parsing of {@code ResourceApi}
@@ -40,7 +40,7 @@ public class ResourceApiMockTest extends BaseHeatApiMockTest {
             new MockResponse().setResponseCode(200).setBody(stringFromResource("/resource_type_list_response.json"))));
 
       try {
-         HeatApi heatApi = api(server.getUrl("/").toString(), "openstack-heat", overrides);
+         HeatApi heatApi = api(server.url("/").toString(), "openstack-heat", overrides);
          ResourceApi api = heatApi.getResourceApi("RegionOne");
 
          List<String> resourceTypes = api.listTypes();

--- a/openstack-heat/src/test/java/org/jclouds/openstack/heat/v1/features/StackApiMockTest.java
+++ b/openstack-heat/src/test/java/org/jclouds/openstack/heat/v1/features/StackApiMockTest.java
@@ -33,8 +33,8 @@ import org.jclouds.openstack.heat.v1.options.ListStackOptions;
 import org.jclouds.openstack.heat.v1.options.UpdateStack;
 import org.testng.annotations.Test;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 
 /**
  * Tests annotation parsing of {@code StackApi}
@@ -55,7 +55,7 @@ public class StackApiMockTest extends BaseHeatApiMockTest {
             new MockResponse().setResponseCode(200).setBody(stringFromResource("/stack_get_response.json"))));
 
       try {
-         HeatApi heatApi = api(server.getUrl("/").toString(), "openstack-heat", overrides);
+         HeatApi heatApi = api(server.url("/").toString(), "openstack-heat", overrides);
          StackApi api = heatApi.getStackApi("RegionOne");
 
          Stack stack = api.get("simple_stack", "3095aefc-09fb-4bc7-b1f0-f21a304e864c");
@@ -78,7 +78,7 @@ public class StackApiMockTest extends BaseHeatApiMockTest {
             new MockResponse().setResponseCode(200).setBody(stringFromResource("/stack_get_response.json"))));
 
       try {
-         HeatApi heatApi = api(server.getUrl("/").toString(), "openstack-heat", overrides);
+         HeatApi heatApi = api(server.url("/").toString(), "openstack-heat", overrides);
          StackApi api = heatApi.getStackApi("RegionOne");
 
          Stack stack = api.get("3095aefc-09fb-4bc7-b1f0-f21a304e864c");
@@ -101,7 +101,7 @@ public class StackApiMockTest extends BaseHeatApiMockTest {
             new MockResponse().setResponseCode(200).setBody(stringFromResource("/stack_list_response.json"))));
 
       try {
-         HeatApi heatApi = api(server.getUrl("/").toString(), "openstack-heat", overrides);
+         HeatApi heatApi = api(server.url("/").toString(), "openstack-heat", overrides);
          StackApi api = heatApi.getStackApi("RegionOne");
 
          List<Stack> stacks = api.list();
@@ -131,7 +131,7 @@ public class StackApiMockTest extends BaseHeatApiMockTest {
             new MockResponse().setResponseCode(200).setBody(stringFromResource("/stack_list_response.json"))));
 
       try {
-         HeatApi heatApi = api(server.getUrl("/").toString(), "openstack-heat", overrides);
+         HeatApi heatApi = api(server.url("/").toString(), "openstack-heat", overrides);
          StackApi api = heatApi.getStackApi("RegionOne");
 
          ListStackOptions options = ListStackOptions.Builder.name("simple_stack").showNested(true).globalTenant(true);
@@ -163,7 +163,7 @@ public class StackApiMockTest extends BaseHeatApiMockTest {
             new MockResponse().setResponseCode(200).setBody(stringFromResource("/stack_resources_list_response.json"))));
 
       try {
-         HeatApi heatApi = api(server.getUrl("/").toString(), "openstack-heat", overrides);
+         HeatApi heatApi = api(server.url("/").toString(), "openstack-heat", overrides);
          StackApi api = heatApi.getStackApi("RegionOne");
 
          List<StackResource> stackResources = api.listStackResources(TEST_STACK_NAME, TEST_STACK_ID);
@@ -193,7 +193,7 @@ public class StackApiMockTest extends BaseHeatApiMockTest {
             new MockResponse().setResponseCode(200).setBody(stringFromResource("/stack_resources_get_response.json"))));
 
       try {
-         HeatApi heatApi = api(server.getUrl("/").toString(), "openstack-heat", overrides);
+         HeatApi heatApi = api(server.url("/").toString(), "openstack-heat", overrides);
          StackApi api = heatApi.getStackApi("RegionOne");
 
          StackResource stackResource = api.getStackResource(TEST_STACK_NAME, TEST_STACK_ID, TEST_STACK_RESOURCE_NAME);
@@ -227,7 +227,7 @@ public class StackApiMockTest extends BaseHeatApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(200).setBody(stringFromResource("/create_stack.json"))));
 
       try {
-         HeatApi heatApi = api(server.getUrl("/").toString(), "openstack-heat", overrides);
+         HeatApi heatApi = api(server.url("/").toString(), "openstack-heat", overrides);
          StackApi api = heatApi.getStackApi("RegionOne");
 
          CreateStack createStack = CreateStack.builder().name(TEST_STACK_NAME).templateUrl("http://10.5.5.121/Installs/cPaaS/YAML/simple_stack.yaml").build();
@@ -257,7 +257,7 @@ public class StackApiMockTest extends BaseHeatApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(200)));
 
       try {
-         HeatApi heatApi = api(server.getUrl("/").toString(), "openstack-heat", overrides);
+         HeatApi heatApi = api(server.url("/").toString(), "openstack-heat", overrides);
          StackApi api = heatApi.getStackApi("RegionOne");
 
          boolean result = api.delete(TEST_STACK_NAME, TEST_STACK_ID);
@@ -284,7 +284,7 @@ public class StackApiMockTest extends BaseHeatApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(202)));
 
       try {
-         HeatApi heatApi = api(server.getUrl("/").toString(), "openstack-heat", overrides);
+         HeatApi heatApi = api(server.url("/").toString(), "openstack-heat", overrides);
          StackApi api = heatApi.getStackApi("RegionOne");
 
          UpdateStack updateOptions = UpdateStack.builder().templateUrl("http://10.5.5.121/Installs/cPaaS/YAML/simple_stack.yaml").build();
@@ -314,7 +314,7 @@ public class StackApiMockTest extends BaseHeatApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(200).setBody(stringFromResource("/resources_metadata.json"))));
 
       try {
-         HeatApi heatApi = api(server.getUrl("/").toString(), "openstack-heat", overrides);
+         HeatApi heatApi = api(server.url("/").toString(), "openstack-heat", overrides);
          StackApi api = heatApi.getStackApi("RegionOne");
 
          Map<String, Object> metadata = api.getStackResourceMetadata(TEST_STACK_NAME, TEST_STACK_ID, RESOURCES_TEST_NAME);

--- a/openstack-heat/src/test/java/org/jclouds/openstack/heat/v1/features/TemplateApiMockTest.java
+++ b/openstack-heat/src/test/java/org/jclouds/openstack/heat/v1/features/TemplateApiMockTest.java
@@ -24,8 +24,8 @@ import org.jclouds.openstack.heat.v1.domain.Template;
 import org.jclouds.openstack.heat.v1.internal.BaseHeatApiMockTest;
 import org.testng.annotations.Test;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 
 /**
  * Tests annotation parsing of {@code StackApi}
@@ -40,7 +40,7 @@ public class TemplateApiMockTest extends BaseHeatApiMockTest {
             new MockResponse().setResponseCode(200).setBody(stringFromResource("/template_get_response.json"))));
 
       try {
-         HeatApi heatApi = api(server.getUrl("/").toString(), "openstack-heat", overrides);
+         HeatApi heatApi = api(server.url("/").toString(), "openstack-heat", overrides);
          TemplateApi api = heatApi.getTemplateApi("RegionOne");
 
          Template template = api.get("simple_stack", "3095aefc-09fb-4bc7-b1f0-f21a304e864c");
@@ -64,7 +64,7 @@ public class TemplateApiMockTest extends BaseHeatApiMockTest {
             new MockResponse().setResponseCode(200).setBody(stringFromResource("/template_validate_response.json"))));
 
       try {
-         HeatApi heatApi = api(server.getUrl("/").toString(), "openstack-heat", overrides);
+         HeatApi heatApi = api(server.url("/").toString(), "openstack-heat", overrides);
          TemplateApi api = heatApi.getTemplateApi("RegionOne");
 
          Template template = api.validate("https://examplevalidateurl.com/exampletemplate.json");

--- a/openstack-marconi/pom.xml
+++ b/openstack-marconi/pom.xml
@@ -93,7 +93,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.squareup.okhttp</groupId>
+      <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
       <scope>test</scope>
     </dependency>

--- a/openstack-marconi/src/test/java/org/jclouds/openstack/marconi/v1/features/ClaimApiMockTest.java
+++ b/openstack-marconi/src/test/java/org/jclouds/openstack/marconi/v1/features/ClaimApiMockTest.java
@@ -16,8 +16,8 @@
  */
 package org.jclouds.openstack.marconi.v1.features;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 import org.jclouds.openstack.marconi.v1.MarconiApi;
 import org.jclouds.openstack.marconi.v1.domain.Claim;
 import org.jclouds.openstack.marconi.v1.domain.Message;
@@ -40,7 +40,7 @@ public class ClaimApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
       server.enqueue(new MockResponse().setResponseCode(201).setBody("[{\"body\": \"{\\\"event\\\":{\\\"name\\\":\\\"HK Java User Group\\\",\\\"attendees\\\":[\\\"bob\\\",\\\"jim\\\",\\\"sally\\\"]}}\", \"age\": 1997, \"href\": \"/v1/queues/jclouds-test/messages/52a645633ac24e6f0be88d44?claim_id=52a64d30ef913e6d05e7f786\", \"ttl\": 86400}, {\"body\": \"{\\\"event\\\":{\\\"name\\\":\\\"SF Java User Group\\\",\\\"attendees\\\":[\\\"bob\\\",\\\"jim\\\",\\\"sally\\\"]}}\", \"age\": 981, \"href\": \"/v1/queues/jclouds-test/messages/52a6495bef913e6d195dcffe?claim_id=52a64d30ef913e6d05e7f786\", \"ttl\": 86400}]"));
 
       try {
-         MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
+         MarconiApi api = api(server.url("/").toString(), "openstack-marconi");
          ClaimApi claimApi = api.getClaimApi("DFW", CLIENT_ID, "jclouds-test");
 
          List<Message> messages = claimApi.claim(300, 200, 2);
@@ -68,7 +68,7 @@ public class ClaimApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
       server.enqueue(new MockResponse().setResponseCode(201).setBody("{\"age\": 209, \"href\": \"/v1/queues/jclouds-test/claims/52a8d23eb04a584f1bbd4f47\", \"messages\": [{\"body\": \"{\\\"event\\\":{\\\"name\\\":\\\"SF Java User Group\\\",\\\"attendees\\\":[\\\"bob\\\",\\\"jim\\\",\\\"sally\\\"]}}\", \"age\": 12182, \"href\": \"/v1/queues/jclouds-test/messages/52a8a379b04a584f2ec2bc3e?claim_id=52a8d23eb04a584f1bbd4f47\", \"ttl\": 86400}, {\"body\": \"{\\\"event\\\":{\\\"name\\\":\\\"Austin Java User Group\\\",\\\"attendees\\\":[\\\"bob\\\",\\\"jim\\\",\\\"sally\\\"]}}\", \"age\": 12182, \"href\": \"/v1/queues/jclouds-test/messages/52a8a379b04a584f2ec2bc3f?claim_id=52a8d23eb04a584f1bbd4f47\", \"ttl\": 86400}], \"ttl\": 300}"));
 
       try {
-         MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
+         MarconiApi api = api(server.url("/").toString(), "openstack-marconi");
          ClaimApi claimApi = api.getClaimApi("DFW", CLIENT_ID, "jclouds-test");
 
          Claim claim = claimApi.get("52a8d23eb04a584f1bbd4f47");
@@ -109,7 +109,7 @@ public class ClaimApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
       server.enqueue(new MockResponse().setResponseCode(204));
 
       try {
-         MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
+         MarconiApi api = api(server.url("/").toString(), "openstack-marconi");
          ClaimApi claimApi = api.getClaimApi("DFW", CLIENT_ID, "jclouds-test");
 
          claimApi.update("52a8d23eb04a584f1bbd4f47", 400);
@@ -129,7 +129,7 @@ public class ClaimApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
       server.enqueue(new MockResponse().setResponseCode(204));
 
       try {
-         MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
+         MarconiApi api = api(server.url("/").toString(), "openstack-marconi");
          ClaimApi claimApi = api.getClaimApi("DFW", CLIENT_ID, "jclouds-test");
 
          boolean success = claimApi.release("52a8d23eb04a584f1bbd4f47");

--- a/openstack-marconi/src/test/java/org/jclouds/openstack/marconi/v1/features/MessageApiMockTest.java
+++ b/openstack-marconi/src/test/java/org/jclouds/openstack/marconi/v1/features/MessageApiMockTest.java
@@ -18,8 +18,8 @@ package org.jclouds.openstack.marconi.v1.features;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 import org.jclouds.openstack.marconi.v1.MarconiApi;
 import org.jclouds.openstack.marconi.v1.domain.CreateMessage;
 import org.jclouds.openstack.marconi.v1.domain.Message;
@@ -47,7 +47,7 @@ public class MessageApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
       server.enqueue(new MockResponse().setResponseCode(201).setBody("{\"partial\": false, \"resources\": [\"/v1/queues/jclouds-test/messages/526550ecef913e655ff84db8\"]}"));
 
       try {
-         MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
+         MarconiApi api = api(server.url("/").toString(), "openstack-marconi");
          MessageApi messageApi = api.getMessageApi("DFW", CLIENT_ID, "jclouds-test");
 
          String json1 = "{\"event\":{\"name\":\"Edmonton Java User Group\",\"attendees\":[\"bob\",\"jim\",\"sally\"]}}";
@@ -75,7 +75,7 @@ public class MessageApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
       server.enqueue(new MockResponse().setResponseCode(201).setBody("{\"partial\": false, \"resources\": [\"/v1/queues/jclouds-test/messages/5265540ef4919b655da1760a\", \"/v1/queues/jclouds-test/messages/5265540ef4919b655da1760b\", \"/v1/queues/jclouds-test/messages/5265540ef4919b655da1760c\"]}"));
 
       try {
-         MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
+         MarconiApi api = api(server.url("/").toString(), "openstack-marconi");
          MessageApi messageApi = api.getMessageApi("DFW", CLIENT_ID, "jclouds-test");
 
          String json1 = "{\"event\":{\"name\":\"Austin Java User Group\",\"attendees\":[\"bob\",\"jim\",\"sally\"]}}";
@@ -109,7 +109,7 @@ public class MessageApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
       server.enqueue(new MockResponse().setResponseCode(204));
 
       try {
-         MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
+         MarconiApi api = api(server.url("/").toString(), "openstack-marconi");
          MessageApi messageApi = api.getMessageApi("DFW", CLIENT_ID, "jclouds-test");
 
          MessageStream messageStream = messageApi.stream();
@@ -133,7 +133,7 @@ public class MessageApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
       server.enqueue(new MockResponse().setResponseCode(204));
 
       try {
-         MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
+         MarconiApi api = api(server.url("/").toString(), "openstack-marconi");
          MessageApi messageApi = api.getMessageApi("DFW", CLIENT_ID, "jclouds-test");
 
          MessageStream messageStream = messageApi.stream();
@@ -165,7 +165,7 @@ public class MessageApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
       server.enqueue(new MockResponse().setResponseCode(204));
 
       try {
-         MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
+         MarconiApi api = api(server.url("/").toString(), "openstack-marconi");
          MessageApi messageApi = api.getMessageApi("DFW", CLIENT_ID, "jclouds-test");
 
          MessageStream messageStream = messageApi.stream(limit(2));
@@ -196,7 +196,7 @@ public class MessageApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
       server.enqueue(new MockResponse().setResponseCode(200).setBody("[{\"body\": \"{\\\"event\\\":{\\\"name\\\":\\\"SF Java User Group\\\",\\\"attendees\\\":[\\\"bob\\\",\\\"jim\\\",\\\"sally\\\"]}}\", \"age\": 1596, \"href\": \"/v1/queues/jclouds-test/messages/messages/52928896b04a584f24883227\", \"ttl\": 86400}, {\"body\": \"{\\\"event\\\":{\\\"name\\\":\\\"Austin Java User Group\\\",\\\"attendees\\\":[\\\"bob\\\",\\\"jim\\\",\\\"sally\\\"]}}\", \"age\": 1596, \"href\": \"/v1/queues/jclouds-test/messages/messages/52928896b04a584f24883228\", \"ttl\": 86400}, {\"body\": \"{\\\"event\\\":{\\\"name\\\":\\\"HK Java User Group\\\",\\\"attendees\\\":[\\\"bob\\\",\\\"jim\\\",\\\"sally\\\"]}}\", \"age\": 1596, \"href\": \"/v1/queues/jclouds-test/messages/messages/52928896b04a584f24883229\", \"ttl\": 86400}]"));
 
       try {
-         MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
+         MarconiApi api = api(server.url("/").toString(), "openstack-marconi");
          MessageApi messageApi = api.getMessageApi("DFW", CLIENT_ID, "jclouds-test");
          List<String> ids = ImmutableList.of("52928896b04a584f24883227", "52928896b04a584f24883228", "52928896b04a584f24883229");
 
@@ -226,7 +226,7 @@ public class MessageApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
       server.enqueue(new MockResponse().setResponseCode(200).setBody("{\"body\": \"{\\\"event\\\":{\\\"name\\\":\\\"Edmonton Java User Group\\\",\\\"attendees\\\":[\\\"bob\\\",\\\"jim\\\",\\\"sally\\\"]}}\", \"age\": 266, \"href\": \"/v1/queues/jclouds-test/messages/5292b30cef913e6d026f4dec\", \"ttl\": 86400}"));
 
       try {
-         MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
+         MarconiApi api = api(server.url("/").toString(), "openstack-marconi");
          MessageApi messageApi = api.getMessageApi("DFW", CLIENT_ID, "jclouds-test");
 
          Message message = messageApi.get("5292b30cef913e6d026f4dec");
@@ -251,7 +251,7 @@ public class MessageApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
       server.enqueue(new MockResponse().setResponseCode(204));
 
       try {
-         MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
+         MarconiApi api = api(server.url("/").toString(), "openstack-marconi");
          MessageApi messageApi = api.getMessageApi("DFW", CLIENT_ID, "jclouds-test");
          List<String> ids = ImmutableList.of("52936b8a3ac24e6ef4c067dd", "5292b30cef913e6d026f4dec");
 
@@ -274,7 +274,7 @@ public class MessageApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
       server.enqueue(new MockResponse().setResponseCode(204));
 
       try {
-         MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
+         MarconiApi api = api(server.url("/").toString(), "openstack-marconi");
          MessageApi messageApi = api.getMessageApi("DFW", CLIENT_ID, "jclouds-test");
 
          boolean success = messageApi.deleteByClaim("52936b8a3ac24e6ef4c067dd", "5292b30cef913e6d026f4dec");

--- a/openstack-marconi/src/test/java/org/jclouds/openstack/marconi/v1/features/QueueApiMockTest.java
+++ b/openstack-marconi/src/test/java/org/jclouds/openstack/marconi/v1/features/QueueApiMockTest.java
@@ -18,9 +18,9 @@ package org.jclouds.openstack.marconi.v1.features;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
-import com.squareup.okhttp.mockwebserver.RecordedRequest;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 
 import org.jclouds.openstack.marconi.v1.MarconiApi;
 import org.jclouds.openstack.marconi.v1.domain.Queue;
@@ -50,7 +50,7 @@ public class QueueApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
       server.enqueue(new MockResponse().setResponseCode(204));
 
       try {
-         MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
+         MarconiApi api = api(server.url("/").toString(), "openstack-marconi");
          QueueApi queueApi = api.getQueueApi("DFW", CLIENT_ID);
          queueApi.create("jclouds-test");
 
@@ -69,7 +69,7 @@ public class QueueApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
       server.enqueue(new MockResponse().setResponseCode(204));
 
       try {
-         MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
+         MarconiApi api = api(server.url("/").toString(), "openstack-marconi");
          QueueApi queueApi = api.getQueueApi("DFW", CLIENT_ID);
          boolean success = queueApi.delete("jclouds-test");
 
@@ -90,7 +90,7 @@ public class QueueApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
       server.enqueue(new MockResponse().setResponseCode(204));
 
       try {
-         MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
+         MarconiApi api = api(server.url("/").toString(), "openstack-marconi");
          QueueApi queueApi = api.getQueueApi("DFW", CLIENT_ID);
          boolean success = queueApi.exists("jclouds-test");
 
@@ -111,7 +111,7 @@ public class QueueApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
       server.enqueue(new MockResponse().setResponseCode(204));
 
       try {
-         MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
+         MarconiApi api = api(server.url("/").toString(), "openstack-marconi");
          QueueApi queueApi = api.getQueueApi("DFW", CLIENT_ID);
 
          List<Queue> queues = queueApi.list(false).concat().toList();
@@ -134,7 +134,7 @@ public class QueueApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
       server.enqueue(new MockResponse().setResponseCode(204));
 
       try {
-         MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
+         MarconiApi api = api(server.url("/").toString(), "openstack-marconi");
          QueueApi queueApi = api.getQueueApi("DFW", CLIENT_ID);
 
          List<Queue> queues = queueApi.list(false).concat().toList();
@@ -161,7 +161,7 @@ public class QueueApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
       server.enqueue(new MockResponse().setResponseCode(204));
 
       try {
-         MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
+         MarconiApi api = api(server.url("/").toString(), "openstack-marconi");
          QueueApi queueApi = api.getQueueApi("DFW", CLIENT_ID);
 
          List<Queue> queues = queueApi.list(false).concat().toList();
@@ -192,7 +192,7 @@ public class QueueApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
       server.enqueue(new MockResponse().setResponseCode(204));
 
       try {
-         MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
+         MarconiApi api = api(server.url("/").toString(), "openstack-marconi");
          QueueApi queueApi = api.getQueueApi("DFW", CLIENT_ID);
 
          Queues queues = queueApi.list(limit(6));
@@ -225,7 +225,7 @@ public class QueueApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
       server.enqueue(new MockResponse().setResponseCode(204));
 
       try {
-         MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
+         MarconiApi api = api(server.url("/").toString(), "openstack-marconi");
          QueueApi queueApi = api.getQueueApi("DFW", CLIENT_ID);
          Map<String, String> metadata = ImmutableMap.of("key1", "value1");
          queueApi.setMetadata("jclouds-test", metadata);
@@ -247,7 +247,7 @@ public class QueueApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
       server.enqueue(new MockResponse().setResponseCode(200).setBody("{\"key1\":\"value1\"}"));
 
       try {
-         MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
+         MarconiApi api = api(server.url("/").toString(), "openstack-marconi");
          QueueApi queueApi = api.getQueueApi("DFW", CLIENT_ID);
          Map<String, String> metadata = queueApi.getMetadata("jclouds-test");
 
@@ -268,7 +268,7 @@ public class QueueApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
       server.enqueue(new MockResponse().setResponseCode(200).setBody("{\"messages\":{\"claimed\":0,\"total\":0,\"free\":0}}"));
 
       try {
-         MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
+         MarconiApi api = api(server.url("/").toString(), "openstack-marconi");
          QueueApi queueApi = api.getQueueApi("DFW", CLIENT_ID);
          QueueStats stats = queueApi.getStats("jclouds-test");
 
@@ -293,7 +293,7 @@ public class QueueApiMockTest extends BaseOpenStackMockTest<MarconiApi> {
       server.enqueue(new MockResponse().setResponseCode(200).setBody("{\"messages\": {\"claimed\": 0, \"oldest\": {\"age\": 0, \"href\": \"/v1/queues/jclouds-test/messages/526558b3f4919b655feba3a7\", \"created\": \"2013-10-21T16:39:15Z\"}, \"total\": 4, \"newest\": {\"age\": 0, \"href\": \"/v1/queues/jclouds-test/messages/526558b33ac24e663fc545e7\", \"created\": \"2013-10-21T16:39:15Z\"}, \"free\": 4}}"));
 
       try {
-         MarconiApi api = api(server.getUrl("/").toString(), "openstack-marconi");
+         MarconiApi api = api(server.url("/").toString(), "openstack-marconi");
          QueueApi queueApi = api.getQueueApi("DFW", CLIENT_ID);
          QueueStats stats = queueApi.getStats("jclouds-test");
 

--- a/openstack-poppy/pom.xml
+++ b/openstack-poppy/pom.xml
@@ -75,7 +75,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.squareup.okhttp</groupId>
+      <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
       <scope>test</scope>
     </dependency>

--- a/openstack-poppy/src/test/java/org/jclouds/openstack/poppy/v1/features/FlavorApiMockTest.java
+++ b/openstack-poppy/src/test/java/org/jclouds/openstack/poppy/v1/features/FlavorApiMockTest.java
@@ -25,8 +25,8 @@ import org.jclouds.openstack.poppy.v1.domain.Flavor;
 import org.jclouds.openstack.poppy.v1.internal.BasePoppyApiMockTest;
 import org.testng.annotations.Test;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 
 /**
  * Tests annotation parsing of {@code FlavorApi}
@@ -41,7 +41,7 @@ public class FlavorApiMockTest extends BasePoppyApiMockTest {
             new MockResponse().setResponseCode(200).setBody(stringFromResource("/poppy_flavor_list_response.json"))));
 
       try {
-         PoppyApi poppyApi = api(server.getUrl("/").toString(), "openstack-poppy", overrides);
+         PoppyApi poppyApi = api(server.url("/").toString(), "openstack-poppy", overrides);
          FlavorApi api = poppyApi.getFlavorApi();
 
          List<Flavor> flavors = api.list().toList();
@@ -64,7 +64,7 @@ public class FlavorApiMockTest extends BasePoppyApiMockTest {
             new MockResponse().setResponseCode(200).setBody(stringFromResource("/poppy_flavor_get_response.json"))));
 
       try {
-         PoppyApi poppyApi = api(server.getUrl("/").toString(), "openstack-poppy", overrides);
+         PoppyApi poppyApi = api(server.url("/").toString(), "openstack-poppy", overrides);
          FlavorApi api = poppyApi.getFlavorApi();
 
          Flavor oneFlavor  = api.get("cdn");
@@ -86,7 +86,7 @@ public class FlavorApiMockTest extends BasePoppyApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404)));
 
       try {
-         PoppyApi poppyApi = api(server.getUrl("/").toString(), "openstack-poppy", overrides);
+         PoppyApi poppyApi = api(server.url("/").toString(), "openstack-poppy", overrides);
          FlavorApi api = poppyApi.getFlavorApi();
 
          Flavor oneFlavor  = api.get("cdn");

--- a/openstack-poppy/src/test/java/org/jclouds/openstack/poppy/v1/features/PoppyApiMockTest.java
+++ b/openstack-poppy/src/test/java/org/jclouds/openstack/poppy/v1/features/PoppyApiMockTest.java
@@ -22,8 +22,8 @@ import org.jclouds.openstack.poppy.v1.PoppyApi;
 import org.jclouds.openstack.poppy.v1.internal.BasePoppyApiMockTest;
 import org.testng.annotations.Test;
 
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 
 /**
  * Tests annotation parsing of {@code PoppyApi}
@@ -37,7 +37,7 @@ public class PoppyApiMockTest extends BasePoppyApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(204)));
 
       try {
-         PoppyApi poppyApi = api(server.getUrl("/").toString(), "openstack-poppy", overrides);
+         PoppyApi poppyApi = api(server.url("/").toString(), "openstack-poppy", overrides);
          boolean online = poppyApi.ping();
 
          assertThat(server.getRequestCount()).isEqualTo(2);
@@ -58,7 +58,7 @@ public class PoppyApiMockTest extends BasePoppyApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(500)));
 
       try {
-         PoppyApi poppyApi = api(server.getUrl("/").toString(), "openstack-poppy", overrides);
+         PoppyApi poppyApi = api(server.url("/").toString(), "openstack-poppy", overrides);
          boolean online = poppyApi.ping();
 
          assertThat(server.getRequestCount()).isEqualTo(3);

--- a/openstack-poppy/src/test/java/org/jclouds/openstack/poppy/v1/features/ServiceApiMockTest.java
+++ b/openstack-poppy/src/test/java/org/jclouds/openstack/poppy/v1/features/ServiceApiMockTest.java
@@ -44,8 +44,8 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.net.HttpHeaders;
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 
 /**
  * Tests annotation parsing of {@code ServiceApi}
@@ -60,7 +60,7 @@ public class ServiceApiMockTest extends BasePoppyApiMockTest {
                         .setHeader(HttpHeaders.LOCATION, "https://poppycdn.org/v1.0/services/123123"));
 
       try {
-         PoppyApi poppyApi = api(server.getUrl("/").toString(), "openstack-poppy", overrides);
+         PoppyApi poppyApi = api(server.url("/").toString(), "openstack-poppy", overrides);
          ServiceApi api = poppyApi.getServiceApi();
 
          CreateService options = CreateService.builder()
@@ -104,7 +104,7 @@ public class ServiceApiMockTest extends BasePoppyApiMockTest {
             new MockResponse().setResponseCode(200).setBody(stringFromResource("/poppy_service_get_response.json"))));
 
       try {
-         PoppyApi poppyApi = api(server.getUrl("/").toString(), "openstack-poppy", overrides);
+         PoppyApi poppyApi = api(server.url("/").toString(), "openstack-poppy", overrides);
          ServiceApi api = poppyApi.getServiceApi();
 
          Service oneService = api.get("96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0");
@@ -127,7 +127,7 @@ public class ServiceApiMockTest extends BasePoppyApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(200).setBody(stringFromResource("/poppy_service_list_response_paged2.json"))));
 
       try {
-         PoppyApi poppyApi = api(server.getUrl("/").toString(), "openstack-poppy", overrides);
+         PoppyApi poppyApi = api(server.url("/").toString(), "openstack-poppy", overrides);
          ServiceApi api = poppyApi.getServiceApi();
 
          // Note: Lazy! Have to actually look at the collection.
@@ -161,7 +161,7 @@ public class ServiceApiMockTest extends BasePoppyApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(200).setBody(stringFromResource("/poppy_service_list_response_paged1.json"))));
 
       try {
-         PoppyApi poppyApi = api(server.getUrl("/").toString(), "openstack-poppy", overrides);
+         PoppyApi poppyApi = api(server.url("/").toString(), "openstack-poppy", overrides);
          ServiceApi api = poppyApi.getServiceApi();
 
          PaginatedCollection<Service> services = api.list(PaginationOptions.Builder.limit(2).marker("abcdefg"));
@@ -191,7 +191,7 @@ public class ServiceApiMockTest extends BasePoppyApiMockTest {
             .setHeader(HttpHeaders.LOCATION, "https://poppycdn.org/v1.0/services/123123"));
 
       try {
-         PoppyApi poppyApi = api(server.getUrl("/").toString(), "openstack-poppy", overrides);
+         PoppyApi poppyApi = api(server.url("/").toString(), "openstack-poppy", overrides);
          ServiceApi api = poppyApi.getServiceApi();
 
          Service toUpdate = api.get("345345");
@@ -218,7 +218,7 @@ public class ServiceApiMockTest extends BasePoppyApiMockTest {
             new MockResponse().setResponseCode(200)));
 
       try {
-         PoppyApi poppyApi = api(server.getUrl("/").toString(), "openstack-poppy", overrides);
+         PoppyApi poppyApi = api(server.url("/").toString(), "openstack-poppy", overrides);
          ServiceApi api = poppyApi.getServiceApi();
 
          boolean result = api.delete("96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0");
@@ -240,7 +240,7 @@ public class ServiceApiMockTest extends BasePoppyApiMockTest {
             new MockResponse().setResponseCode(200)));
 
       try {
-         PoppyApi poppyApi = api(server.getUrl("/").toString(), "openstack-poppy", overrides);
+         PoppyApi poppyApi = api(server.url("/").toString(), "openstack-poppy", overrides);
          ServiceApi api = poppyApi.getServiceApi();
 
          boolean result = api.deleteAsset("96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0", "/images/1.jpg");
@@ -263,7 +263,7 @@ public class ServiceApiMockTest extends BasePoppyApiMockTest {
             new MockResponse().setResponseCode(200)));
 
       try {
-         PoppyApi poppyApi = api(server.getUrl("/").toString(), "openstack-poppy", overrides);
+         PoppyApi poppyApi = api(server.url("/").toString(), "openstack-poppy", overrides);
          ServiceApi api = poppyApi.getServiceApi();
 
          boolean result = api.deleteAssets("96737ae3-cfc1-4c72-be88-5d0e7cc9a3f0");

--- a/rackspace-autoscale/pom.xml
+++ b/rackspace-autoscale/pom.xml
@@ -99,7 +99,7 @@
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.squareup.okhttp</groupId>
+      <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
       <scope>test</scope>
     </dependency>

--- a/rackspace-autoscale/src/test/java/org/jclouds/rackspace/autoscale/v1/features/GroupApiMockTest.java
+++ b/rackspace-autoscale/src/test/java/org/jclouds/rackspace/autoscale/v1/features/GroupApiMockTest.java
@@ -44,8 +44,8 @@ import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 
 /**
  * Tests GroupApi Guice wiring and parsing
@@ -59,7 +59,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(201).setBody(stringFromResource("/autoscale_groups_create_response.json"))));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          GroupConfiguration groupConfiguration = GroupConfiguration.builder()
@@ -156,7 +156,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404).setBody(stringFromResource("/autoscale_groups_create_response.json"))));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          GroupConfiguration groupConfiguration = GroupConfiguration.builder()
@@ -210,7 +210,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(200).setBody(stringFromResource("/autoscale_groups_list_response.json"))));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          FluentIterable<GroupState> groupStates = api.listGroupStates();
@@ -247,7 +247,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404).setBody(stringFromResource("/autoscale_groups_list_response.json"))));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          FluentIterable<GroupState> groupStates = api.listGroupStates();
@@ -273,7 +273,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(200).setBody(stringFromResource("/autoscale_groups_get_response.json"))));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          Group g = api.get("1234567890");
@@ -300,7 +300,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404).setBody(stringFromResource("/autoscale_groups_get_response.json"))));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          Group g = api.get("1234567890");
@@ -326,7 +326,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(200)));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          boolean success = api.delete("1234567890");
@@ -352,7 +352,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404)));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          boolean success = api.delete("1234567890");
@@ -378,7 +378,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(200).setBody(stringFromResource("/autoscale_groups_state_response.json"))));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          GroupState gs = api.getState("1234567890");
@@ -406,7 +406,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404).setBody(stringFromResource("/autoscale_groups_state_response.json"))));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          GroupState gs = api.getState("1234567890");
@@ -432,7 +432,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(204)));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          boolean success = api.pause("1234567890");
@@ -458,7 +458,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404)));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          boolean success = api.pause("1234567890");
@@ -484,7 +484,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(204)));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          boolean success = api.resume("1234567890");
@@ -510,7 +510,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404)));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          boolean success = api.resume("1234567890");
@@ -536,7 +536,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(200).setBody(stringFromResource("/autoscale_groups_configuration_get_response.json"))));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          GroupConfiguration gc = api.getGroupConfiguration("1234567890");
@@ -563,7 +563,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404).setBody(stringFromResource("/autoscale_groups_configuration_get_response.json"))));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          GroupConfiguration gc = api.getGroupConfiguration("1234567890");
@@ -589,7 +589,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(200).setBody(stringFromResource("/autoscale_groups_launch_configuration_get_response.json"))));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          LaunchConfiguration lc = api.getLaunchConfiguration("1234567890");
@@ -616,7 +616,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404).setBody(stringFromResource("/autoscale_groups_launch_configuration_get_response.json"))));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          LaunchConfiguration lc = api.getLaunchConfiguration("1234567890");
@@ -642,7 +642,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(200)));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          GroupConfiguration gc = GroupConfiguration.builder()
@@ -676,7 +676,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404)));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          GroupConfiguration gc = GroupConfiguration.builder()
@@ -710,7 +710,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(200)));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          LaunchConfiguration lc = LaunchConfiguration.builder()
@@ -748,7 +748,7 @@ public class GroupApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404)));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          GroupApi api = autoscaleApi.getGroupApi("DFW");
 
          LaunchConfiguration lc = LaunchConfiguration.builder()

--- a/rackspace-autoscale/src/test/java/org/jclouds/rackspace/autoscale/v1/features/ScalingPolicyApiMockTest.java
+++ b/rackspace-autoscale/src/test/java/org/jclouds/rackspace/autoscale/v1/features/ScalingPolicyApiMockTest.java
@@ -36,8 +36,8 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Lists;
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 
 /**
  * Tests Scaling Policy Api Guice wiring and parsing
@@ -51,7 +51,7 @@ public class ScalingPolicyApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(201).setBody(stringFromResource("/autoscale_policy_create_response.json"))));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          PolicyApi api = autoscaleApi.getPolicyApi("DFW", "groupId1");
 
          List<CreateScalingPolicy> scalingPolicies = Lists.newArrayList();
@@ -94,7 +94,7 @@ public class ScalingPolicyApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404).setBody(stringFromResource("/autoscale_policy_create_response.json"))));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          PolicyApi api = autoscaleApi.getPolicyApi("DFW", "groupId1");
 
          List<CreateScalingPolicy> scalingPolicies = Lists.newArrayList();
@@ -131,7 +131,7 @@ public class ScalingPolicyApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(201).setBody(stringFromResource("/autoscale_policy_schedule_cron_create_response.json"))));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          PolicyApi api = autoscaleApi.getPolicyApi("DFW", "groupId1");
 
          List<CreateScalingPolicy> scalingPolicies = Lists.newArrayList();
@@ -178,7 +178,7 @@ public class ScalingPolicyApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(201).setBody(stringFromResource("/autoscale_policy_schedule_at_create_response.json"))));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          PolicyApi api = autoscaleApi.getPolicyApi("DFW", "groupId1");
 
          List<CreateScalingPolicy> scalingPolicies = Lists.newArrayList();
@@ -225,7 +225,7 @@ public class ScalingPolicyApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(201).setBody(stringFromResource("/autoscale_policy_list_response.json"))));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          PolicyApi api = autoscaleApi.getPolicyApi("DFW", "groupId1");
 
          FluentIterable<ScalingPolicy> scalingPolicyResponse = api.list();
@@ -257,7 +257,7 @@ public class ScalingPolicyApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404).setBody(stringFromResource("/autoscale_policy_list_response.json"))));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          PolicyApi api = autoscaleApi.getPolicyApi("DFW", "groupId1");
 
          FluentIterable<ScalingPolicy> scalingPolicyResponse = api.list();
@@ -283,7 +283,7 @@ public class ScalingPolicyApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(201).setBody(stringFromResource("/autoscale_policy_get_response.json"))));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          PolicyApi api = autoscaleApi.getPolicyApi("DFW", "groupId1");
 
          ScalingPolicy scalingPolicyResponse = api.get("policyId");
@@ -314,7 +314,7 @@ public class ScalingPolicyApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404).setBody(stringFromResource("/autoscale_policy_get_response.json"))));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          PolicyApi api = autoscaleApi.getPolicyApi("DFW", "groupId1");
 
          ScalingPolicy scalingPolicyResponse = api.get("policyId");
@@ -340,7 +340,7 @@ public class ScalingPolicyApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(201)));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          PolicyApi api = autoscaleApi.getPolicyApi("DFW", "groupId1");
 
          CreateScalingPolicy scalingPolicy = CreateScalingPolicy.builder()
@@ -374,7 +374,7 @@ public class ScalingPolicyApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404)));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          PolicyApi api = autoscaleApi.getPolicyApi("DFW", "groupId1");
 
          CreateScalingPolicy scalingPolicy = CreateScalingPolicy.builder()
@@ -408,7 +408,7 @@ public class ScalingPolicyApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(201)));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          PolicyApi api = autoscaleApi.getPolicyApi("DFW", "groupId1");
 
          boolean result = api.delete("policyId");
@@ -434,7 +434,7 @@ public class ScalingPolicyApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404)));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          PolicyApi api = autoscaleApi.getPolicyApi("DFW", "groupId1");
 
          boolean result = api.delete("policyId");
@@ -460,7 +460,7 @@ public class ScalingPolicyApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(201)));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          PolicyApi api = autoscaleApi.getPolicyApi("DFW", "groupId1");
 
          boolean result = api.execute("policyId");
@@ -486,7 +486,7 @@ public class ScalingPolicyApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404)));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          PolicyApi api = autoscaleApi.getPolicyApi("DFW", "groupId1");
 
          boolean result = api.execute("policyId");

--- a/rackspace-autoscale/src/test/java/org/jclouds/rackspace/autoscale/v1/features/WebhookApiMockTest.java
+++ b/rackspace-autoscale/src/test/java/org/jclouds/rackspace/autoscale/v1/features/WebhookApiMockTest.java
@@ -32,8 +32,8 @@ import org.testng.annotations.Test;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 
 /**
  * Tests WebhookApi Guice wiring and parsing
@@ -47,7 +47,7 @@ public class WebhookApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(201).setBody(stringFromResource("/autoscale_webhook_create_response.json"))));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          WebhookApi api = autoscaleApi.getWebhookApi("DFW", "1234567890", "321456");
 
          FluentIterable<Webhook> webhooks = api.create("PagerDuty", ImmutableMap.<String, Object>of("notes", "PagerDuty will fire this webhook"));
@@ -74,7 +74,7 @@ public class WebhookApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404).setBody(stringFromResource("/autoscale_webhook_create_response.json"))));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          WebhookApi api = autoscaleApi.getWebhookApi("DFW", "1234567890", "321456");
 
          FluentIterable<Webhook> webhooks = api.create("PagerDuty", ImmutableMap.<String, Object>of("notes", "PagerDuty will fire this webhook"));
@@ -100,7 +100,7 @@ public class WebhookApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(201).setBody(stringFromResource("/autoscale_webhooks_create_response.json"))));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          WebhookApi api = autoscaleApi.getWebhookApi("DFW", "1234567890", "321456");
 
          FluentIterable<Webhook> webhooks = api.create(ImmutableList.of(
@@ -131,7 +131,7 @@ public class WebhookApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404).setBody(stringFromResource("/autoscale_webhooks_create_response.json"))));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          WebhookApi api = autoscaleApi.getWebhookApi("DFW", "1234567890", "321456");
 
          FluentIterable<Webhook> webhooks = api.create(ImmutableList.of(
@@ -160,7 +160,7 @@ public class WebhookApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(201).setBody(stringFromResource("/autoscale_webhook_list_response.json"))));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          WebhookApi api = autoscaleApi.getWebhookApi("DFW", "1234567890", "321456");
 
          FluentIterable<Webhook> webhooks = api.list();
@@ -188,7 +188,7 @@ public class WebhookApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404).setBody(stringFromResource("/autoscale_webhook_list_response.json"))));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          WebhookApi api = autoscaleApi.getWebhookApi("DFW", "1234567890", "321456");
 
          FluentIterable<Webhook> webhooks = api.list();
@@ -214,7 +214,7 @@ public class WebhookApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(201)));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          WebhookApi api = autoscaleApi.getWebhookApi("DFW", "1234567890", "321456");
 
          boolean success = api.update("5555", "alice", ImmutableMap.<String, Object>of("notes", "this is for Alice"));
@@ -240,7 +240,7 @@ public class WebhookApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404)));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          WebhookApi api = autoscaleApi.getWebhookApi("DFW", "1234567890", "321456");
 
          boolean success = api.update("5555", "alice", ImmutableMap.<String, Object>of("notes", "this is for Alice"));
@@ -266,7 +266,7 @@ public class WebhookApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(201).setBody(stringFromResource("/autoscale_webhook_get_response.json"))));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          WebhookApi api = autoscaleApi.getWebhookApi("DFW", "1234567890", "321456");
 
          Webhook webhook = api.get("5555");
@@ -293,7 +293,7 @@ public class WebhookApiMockTest extends BaseAutoscaleApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404).setBody(stringFromResource("/autoscale_webhook_get_response.json"))));
 
       try {
-         AutoscaleApi autoscaleApi = api(server.getUrl("/").toString(), "rackspace-autoscale", overrides);
+         AutoscaleApi autoscaleApi = api(server.url("/").toString(), "rackspace-autoscale", overrides);
          WebhookApi api = autoscaleApi.getWebhookApi("DFW", "1234567890", "321456");
 
          Webhook webhook = api.get("5555");

--- a/rackspace-cloudbigdata-us/pom.xml
+++ b/rackspace-cloudbigdata-us/pom.xml
@@ -111,7 +111,7 @@
     	<version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.squareup.okhttp</groupId>
+      <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
       <scope>test</scope>
     </dependency>

--- a/rackspace-cloudbigdata/pom.xml
+++ b/rackspace-cloudbigdata/pom.xml
@@ -104,7 +104,7 @@
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.squareup.okhttp</groupId>
+      <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
       <scope>test</scope>
     </dependency>

--- a/rackspace-cloudbigdata/src/test/java/org/jclouds/rackspace/cloudbigdata/v1/features/ClusterApiMockTest.java
+++ b/rackspace-cloudbigdata/src/test/java/org/jclouds/rackspace/cloudbigdata/v1/features/ClusterApiMockTest.java
@@ -34,8 +34,8 @@ import org.jclouds.rackspace.cloudbigdata.v1.internal.BaseCloudBigDataApiMockTes
 import org.testng.annotations.Test;
 
 import com.google.common.collect.FluentIterable;
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 
 /**
  * Tests ProfileApi Guice wiring and parsing
@@ -49,7 +49,7 @@ public class ClusterApiMockTest extends BaseCloudBigDataApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(201).setBody(stringFromResource("/cluster_create_response.json"))));
 
       try {
-         CloudBigDataApi cbdApi = api(server.getUrl("/").toString(), "rackspace-cloudbigdata", overrides);
+         CloudBigDataApi cbdApi = api(server.url("/").toString(), "rackspace-cloudbigdata", overrides);
          ClusterApi api = cbdApi.getClusterApi("ORD");
 
          CreateCluster createCluster = CreateCluster.builder()
@@ -95,7 +95,7 @@ public class ClusterApiMockTest extends BaseCloudBigDataApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404).setBody(stringFromResource("/cluster_create_response.json"))));
 
       try {
-         CloudBigDataApi cbdApi = api(server.getUrl("/").toString(), "rackspace-cloudbigdata", overrides);
+         CloudBigDataApi cbdApi = api(server.url("/").toString(), "rackspace-cloudbigdata", overrides);
          ClusterApi api = cbdApi.getClusterApi("ORD");
 
          CreateCluster createCluster = CreateCluster.builder()
@@ -129,7 +129,7 @@ public class ClusterApiMockTest extends BaseCloudBigDataApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(201).setBody(stringFromResource("/cluster_get_response.json"))));
 
       try {
-         CloudBigDataApi cbdApi = api(server.getUrl("/").toString(), "rackspace-cloudbigdata", overrides);
+         CloudBigDataApi cbdApi = api(server.url("/").toString(), "rackspace-cloudbigdata", overrides);
          ClusterApi api = cbdApi.getClusterApi("ORD");
 
          Cluster cluster = api.get("5");
@@ -167,7 +167,7 @@ public class ClusterApiMockTest extends BaseCloudBigDataApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404).setBody(stringFromResource("/cluster_get_response.json"))));
 
       try {
-         CloudBigDataApi cbdApi = api(server.getUrl("/").toString(), "rackspace-cloudbigdata", overrides);
+         CloudBigDataApi cbdApi = api(server.url("/").toString(), "rackspace-cloudbigdata", overrides);
          ClusterApi api = cbdApi.getClusterApi("ORD");
 
          Cluster cluster = api.get("5");
@@ -193,7 +193,7 @@ public class ClusterApiMockTest extends BaseCloudBigDataApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(201).setBody(stringFromResource("/cluster_list_response.json"))));
 
       try {
-         CloudBigDataApi cbdApi = api(server.getUrl("/").toString(), "rackspace-cloudbigdata", overrides);
+         CloudBigDataApi cbdApi = api(server.url("/").toString(), "rackspace-cloudbigdata", overrides);
          ClusterApi api = cbdApi.getClusterApi("ORD");
 
          FluentIterable<Cluster> clusters = api.list();
@@ -233,7 +233,7 @@ public class ClusterApiMockTest extends BaseCloudBigDataApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404).setBody(stringFromResource("/cluster_list_response.json"))));
 
       try {
-         CloudBigDataApi cbdApi = api(server.getUrl("/").toString(), "rackspace-cloudbigdata", overrides);
+         CloudBigDataApi cbdApi = api(server.url("/").toString(), "rackspace-cloudbigdata", overrides);
          ClusterApi api = cbdApi.getClusterApi("ORD");
 
          FluentIterable<Cluster> clusters = api.list();
@@ -260,7 +260,7 @@ public class ClusterApiMockTest extends BaseCloudBigDataApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(201).setBody(stringFromResource("/cluster_delete_response.json"))));
 
       try {
-         CloudBigDataApi cbdApi = api(server.getUrl("/").toString(), "rackspace-cloudbigdata", overrides);
+         CloudBigDataApi cbdApi = api(server.url("/").toString(), "rackspace-cloudbigdata", overrides);
          ClusterApi api = cbdApi.getClusterApi("ORD");
 
          Cluster cluster = api.delete("5");
@@ -298,7 +298,7 @@ public class ClusterApiMockTest extends BaseCloudBigDataApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404).setBody(stringFromResource("/cluster_delete_response.json"))));
 
       try {
-         CloudBigDataApi cbdApi = api(server.getUrl("/").toString(), "rackspace-cloudbigdata", overrides);
+         CloudBigDataApi cbdApi = api(server.url("/").toString(), "rackspace-cloudbigdata", overrides);
          ClusterApi api = cbdApi.getClusterApi("ORD");
 
          Cluster cluster = api.delete("5");
@@ -324,7 +324,7 @@ public class ClusterApiMockTest extends BaseCloudBigDataApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(201).setBody(stringFromResource("/cluster_resize_response.json"))));
 
       try {
-         CloudBigDataApi cbdApi = api(server.getUrl("/").toString(), "rackspace-cloudbigdata", overrides);
+         CloudBigDataApi cbdApi = api(server.url("/").toString(), "rackspace-cloudbigdata", overrides);
          ClusterApi api = cbdApi.getClusterApi("ORD");
 
          Cluster cluster = api.resize("5", 10);
@@ -362,7 +362,7 @@ public class ClusterApiMockTest extends BaseCloudBigDataApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404).setBody(stringFromResource("/cluster_resize_response.json"))));
 
       try {
-         CloudBigDataApi cbdApi = api(server.getUrl("/").toString(), "rackspace-cloudbigdata", overrides);
+         CloudBigDataApi cbdApi = api(server.url("/").toString(), "rackspace-cloudbigdata", overrides);
          ClusterApi api = cbdApi.getClusterApi("ORD");
 
          Cluster cluster = api.resize("5", 10);

--- a/rackspace-cloudbigdata/src/test/java/org/jclouds/rackspace/cloudbigdata/v1/features/ProfileApiMockTest.java
+++ b/rackspace-cloudbigdata/src/test/java/org/jclouds/rackspace/cloudbigdata/v1/features/ProfileApiMockTest.java
@@ -32,8 +32,8 @@ import org.jclouds.rackspace.cloudbigdata.v1.internal.BaseCloudBigDataApiMockTes
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
-import com.squareup.okhttp.mockwebserver.MockResponse;
-import com.squareup.okhttp.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 
 /**
  * Tests ProfileApi Guice wiring and parsing
@@ -47,7 +47,7 @@ public class ProfileApiMockTest extends BaseCloudBigDataApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(201).setBody(stringFromResource("/profile_create_response.json"))));
 
       try {
-         CloudBigDataApi cbdApi = api(server.getUrl("/").toString(), "rackspace-cloudbigdata", overrides);
+         CloudBigDataApi cbdApi = api(server.url("/").toString(), "rackspace-cloudbigdata", overrides);
          ProfileApi api = cbdApi.getProfileApi("ORD");
 
          CreateProfile createProfile = CreateProfile.builder()
@@ -96,7 +96,7 @@ public class ProfileApiMockTest extends BaseCloudBigDataApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404).setBody(stringFromResource("/profile_create_response.json"))));
 
       try {
-         CloudBigDataApi cbdApi = api(server.getUrl("/").toString(), "rackspace-cloudbigdata", overrides);
+         CloudBigDataApi cbdApi = api(server.url("/").toString(), "rackspace-cloudbigdata", overrides);
          ProfileApi api = cbdApi.getProfileApi("ORD");
 
          CreateProfile createProfile = CreateProfile.builder()
@@ -137,7 +137,7 @@ public class ProfileApiMockTest extends BaseCloudBigDataApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(201).setBody(stringFromResource("/profile_get_response.json"))));
 
       try {
-         CloudBigDataApi cbdApi = api(server.getUrl("/").toString(), "rackspace-cloudbigdata", overrides);
+         CloudBigDataApi cbdApi = api(server.url("/").toString(), "rackspace-cloudbigdata", overrides);
          ProfileApi api = cbdApi.getProfileApi("ORD");
          Profile profile = api.get();
 
@@ -170,7 +170,7 @@ public class ProfileApiMockTest extends BaseCloudBigDataApiMockTest {
       server.enqueue(addCommonHeaders(new MockResponse().setResponseCode(404).setBody(stringFromResource("/profile_get_response.json"))));
 
       try {
-         CloudBigDataApi cbdApi = api(server.getUrl("/").toString(), "rackspace-cloudbigdata", overrides);
+         CloudBigDataApi cbdApi = api(server.url("/").toString(), "rackspace-cloudbigdata", overrides);
          ProfileApi api = cbdApi.getProfileApi("ORD");
          Profile profile = api.get();
 


### PR DESCRIPTION
The JClouds project module upgrades the okhttp server library and related dependencies such as mockwebserver from 2.2.0 to 3.14.9. The vendor switched the groupId declaration from com.squareup.okhttp to com.squareup.okhttp3.

Adjust imports and api calls for newer okhttp vers